### PR TITLE
Convert typedef'd enums to use NS_ENUM() macro

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -21,12 +21,12 @@ extern NSString * const FCModelUpdateNotification;
 extern NSString * const FCModelDeleteNotification;
 extern NSString * const FCModelInstanceKey;
 
-typedef enum {
+typedef NS_ENUM(NSInteger, FCModelSaveResult) {
     FCModelSaveFailed = 0, // SQLite refused a query. Check .lastSQLiteError
     FCModelSaveRefused,    // The instance blocked the operation from a should* method.
     FCModelSaveSucceeded,
     FCModelSaveNoChanges
-} FCModelSaveResult;
+};
 
 @interface FCModel : NSObject
 

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -33,13 +33,13 @@ static NSMutableDictionary *g_primaryKeyFieldName = NULL;
 
 
 // FCFieldInfo is used for NULL/NOT NULL rules and default values
-typedef enum {
+typedef NS_ENUM(NSInteger, FCFieldType) {
     FCFieldTypeOther = 0,
     FCFieldTypeText,
     FCFieldTypeInteger,
     FCFieldTypeDouble,
     FCFieldTypeBool
-} FCFieldType;
+};
 
 @interface FCFieldInfo : NSObject
 @property (nonatomic, assign) BOOL nullAllowed;


### PR DESCRIPTION
This has plenty of benefits, including better code completion and error checking than other methods. For a nice summary on it, check out [NSHipster’s article](http://nshipster.com/ns_enum-ns_options/).
