### PR TITLE
NSDate & NSURL are now converted after external update

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -475,7 +475,7 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
                 }
                 
                 // NSLog(@"%@ %@ updating \"%@\" [%@]=>[%@]", NSStringFromClass(self.class), self.primaryKey, fieldName, existing, fieldValue);
-                [self setValue:fieldValue forKeyPath:fieldName];
+                [self decodeFieldValue:fieldValue intoPropertyName:fieldName];
                 if (! valueIsStillChanged) [self.changedProperties removeObjectForKey:fieldName];
                 didUpdate = YES;
             }


### PR DESCRIPTION
When external update is performed (for example with executeUpdateQuery:), current version doesn't convert NSDate and NSURL values to respective objects in reloaded entities. This commit fixes that.

Maybe there are more instances of setValue:forKeyPath: that should be replaced with decodeFieldValue:intoPropertyName:, but I wasn't sure about that.
