### PR TITLE
Save FMDB errors before calling -rollback.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,10 @@ NSString *dbPath = [documentsPath stringByAppendingPathComponent:@"testDB.sqlite
 
     // My custom failure handling. Yours may vary.
     void (^failedAt)(int statement) = ^(int statement){
+        int lastErrorCode = db.lastErrorCode;
+        NSString *lastErrorMessage = db.lastErrorMessage;
         [db rollback];
-        NSAssert3(0, @"Migration statement %d failed, code %d: %@", statement, db.lastErrorCode, db.lastErrorMessage);
+        NSAssert3(0, @"Migration statement %d failed, code %d: %@", statement, lastErrorCode, lastErrorMessage);
     };
 
     if (*schemaVersion < 1) {

--- a/example/FCModelTest Tests/FCModelTest_Tests.m
+++ b/example/FCModelTest Tests/FCModelTest_Tests.m
@@ -75,8 +75,10 @@
         [db beginTransaction];
         
         void (^failedAt)(int statement) = ^(int statement){
+            int lastErrorCode = db.lastErrorCode;
+            NSString *lastErrorMessage = db.lastErrorMessage;
             [db rollback];
-            NSAssert3(0, @"Migration statement %d failed, code %d: %@", statement, db.lastErrorCode, db.lastErrorMessage);
+            NSAssert3(0, @"Migration statement %d failed, code %d: %@", statement, lastErrorCode, lastErrorMessage);
         };
         
         if (*schemaVersion < 1) {

--- a/example/FCModelTest/AppDelegate.m
+++ b/example/FCModelTest/AppDelegate.m
@@ -28,8 +28,10 @@
         [db beginTransaction];
         
         void (^failedAt)(int statement) = ^(int statement){
+            int lastErrorCode = db.lastErrorCode;
+            NSString *lastErrorMessage = db.lastErrorMessage;
             [db rollback];
-            NSAssert3(0, @"Migration statement %d failed, code %d: %@", statement, db.lastErrorCode, db.lastErrorMessage);
+            NSAssert3(0, @"Migration statement %d failed, code %d: %@", statement, lastErrorCode, lastErrorMessage);
         };
 
         if (*schemaVersion < 1) {


### PR DESCRIPTION
Errors in the migration statements were resulting incorrect exceptions (e.g., "Migration statement 1 failed, code 0: not an error") because `lastErrorCode` and `lastErrorMessage` were being overwritten by the successful `[db rollback]`.
