### PR TITLE
SQLCipher with FCModel - I need to prep the db before openDatabase: will work

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -37,6 +37,7 @@ typedef NS_ENUM(NSInteger, FCModelSaveResult) {
 @property (readonly) NSError *lastSQLiteError;
 
 + (void)openDatabaseAtPath:(NSString *)path withSchemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder;
++ (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder;
 
 // Feel free to operate on the same database queue with your own queries (IMPORTANT: READ THE NEXT METHOD DEFINITION)
 + (FMDatabaseQueue *)databaseQueue;

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -711,13 +711,17 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
 
 #pragma mark - Database management
 
-+ (void)openDatabaseAtPath:(NSString *)path withSchemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder
++ (void)openDatabaseAtPath:(NSString *)path withSchemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder { [self openDatabaseAtPath:path withDatabaseInitializer:nil schemaBuilder:schemaBuilder]; }
+
++ (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder
 {
     g_databaseQueue = [FMDatabaseQueue databaseQueueWithPath:path];
     g_fieldInfo = [NSMutableDictionary dictionary];
     g_primaryKeyFieldName = [NSMutableDictionary dictionary];
     
     [g_databaseQueue inDatabase:^(FMDatabase *db) {
+        if (databaseInitializer) databaseInitializer(db);
+        
         int startingSchemaVersion = 0;
         FMResultSet *rs = [db executeQuery:@"SELECT value FROM _FCModelMetadata WHERE key = 'schema_version'"];
         if ([rs next]) {


### PR DESCRIPTION
I have FCModel working great, almost right out of the box, with [SQLCipher](http://sqlcipher.net/). I just have to run either `sqlite3_key(db.sqliteHandle, key, strlen(key));` or `[db executeUpdate:@"PRAGMA key = 'passphrase'"];` before FCModel attempts to read from its model metadata table.

It seemed that the cleanest and most general way to do that was to add an initializer block that is run before FCModel does anything with the database. I'm not sure if this would be useful for any other cases though, so let me know if you can think of way that I could refactor this that might be simpler or more useful.
