### PR TITLE
fix precision issue insert NSDecimalNumber

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -222,6 +222,8 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
         return [(NSURL *)value absoluteString];
     } else if ([value isKindOfClass:NSDate.class]) {
         return [NSNumber numberWithInteger:[(NSDate *)value timeIntervalSince1970]];
+    } else if ([value isKindOfClass:[NSDecimalNumber class]]) {
+        return [value stringValue];
     } else {
         return value;
     }


### PR DESCRIPTION
if insert NSDecimalNumber directly into sqlite, it will have precision
issue. 
NSDecimalNumber 3.33 will become 3.2999999999

so convert NSDecimalNumber it into NSString before insert will solve this problem
