### PR TITLE
NSDate overflow for 32-bit NSInteger's

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -212,10 +212,10 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
 
     if ( (oldValue = change[NSKeyValueChangeOldKey]) && (newValue = change[NSKeyValueChangeNewKey]) ) {
         if ([oldValue isKindOfClass:[NSURL class]]) oldValue = ((NSURL *)oldValue).absoluteString;
-        else if ([oldValue isKindOfClass:[NSDate class]]) oldValue = [NSNumber numberWithInteger:[(NSDate *)oldValue timeIntervalSince1970]];
+        else if ([oldValue isKindOfClass:[NSDate class]]) oldValue = [NSNumber numberWithLongLong:[(NSDate *)oldValue timeIntervalSince1970]];
 
         if ([newValue isKindOfClass:[NSURL class]]) newValue = ((NSURL *)newValue).absoluteString;
-        else if ([newValue isKindOfClass:[NSDate class]]) newValue = [NSNumber numberWithInteger:[(NSDate *)newValue timeIntervalSince1970]];
+        else if ([newValue isKindOfClass:[NSDate class]]) newValue = [NSNumber numberWithLongLong:[(NSDate *)newValue timeIntervalSince1970]];
 
         if ([oldValue isEqual:newValue]) return;
     }
@@ -246,7 +246,7 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
     } else if ([instanceValue isKindOfClass:NSURL.class]) {
         return [(NSURL *)instanceValue absoluteString];
     } else if ([instanceValue isKindOfClass:NSDate.class]) {
-        return [NSNumber numberWithInteger:[(NSDate *)instanceValue timeIntervalSince1970]];
+        return [NSNumber numberWithLongLong:[(NSDate *)instanceValue timeIntervalSince1970]];
     }
 
     return instanceValue;
@@ -268,7 +268,7 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
         if (databaseValue && strncmp(attrs, "NSURL", 5) == 0) {
             return [NSURL URLWithString:databaseValue];
         } else if (databaseValue && strncmp(attrs, "NSDate", 6) == 0) {
-            return [NSDate dateWithTimeIntervalSince1970:[databaseValue integerValue]];
+            return [NSDate dateWithTimeIntervalSince1970:[databaseValue longLongValue]];
         } else if (databaseValue && strncmp(attrs, "NSDictionary", 12) == 0) {
             NSDictionary *dict = [NSPropertyListSerialization propertyListWithData:databaseValue options:kCFPropertyListImmutable format:NULL error:NULL];
             return dict && [dict isKindOfClass:NSDictionary.class] ? dict : @{};


### PR DESCRIPTION
Ran into this problem recently for "large" dates. Internally FCModel was casting the double returned from `-timeIntervalSince1970` to an `NSInteger` which could be 32 or 64 bits.

Some fun debugger commands on a 32 bit device illustrates the problem

```
(lldb) po [NSDate distantFuture]
4001-01-01 00:00:00 +0000
(lldb) p (double)[[NSDate distantFuture] timeIntervalSince1970]
(double) $12 = 64092211200
(lldb) po [NSNumber numberWithInteger:(double)[[NSDate distantFuture] timeIntervalSince1970]]
-2147483648
```

I've gone with the easy fix of switching to `-numberWithLongLong` rather than the architecture dependent `-numberWithInteger`.
