### PR TITLE
Fixes a crash due to missing unique map init when creating new instances

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -603,7 +603,9 @@ typedef NS_ENUM(NSInteger, FCFieldType) {
         [NSNotificationCenter.defaultCenter addObserver:self selector:@selector(saveByNotification:) name:FCModelSaveNotification object:nil];
         existsInDatabase = existsInDB;
         deleted = NO;
-
+        
+        [self.class uniqueMapInit];
+        
         [g_fieldInfo[self.class] enumerateKeysAndObjectsUsingBlock:^(NSString *key, id obj, BOOL *stop) {
             FCFieldInfo *info = (FCFieldInfo *)obj;
             


### PR DESCRIPTION
Previously the following line would crash if this was the first interaction with the model, because `g_instancesReadLock` was not initialized.

```
dispatch_semaphore_wait(g_instancesReadLock, DISPATCH_TIME_FOREVER);
```

The following lines would also not work without this change:

```
if (! classCache) classCache = g_instances[(id) self.class] = [NSMapTable strongToWeakObjectsMapTable];
```
