### PR TITLE
Fixes a minor warning regarding shadowing of local variable

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1143,8 +1143,8 @@ static inline void onMainThreadAsync(void (^block)())
     
     if (sendQueuedNotifications) {
         onMainThreadAsync(^{
-            [notificationsToSend enumerateKeysAndObjectsUsingBlock:^(Class class, NSDictionary *notificationsForClass, BOOL *stop) {
-                [notificationsForClass enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSSet *objects, BOOL *stop) {
+            [notificationsToSend enumerateKeysAndObjectsUsingBlock:^(Class class, NSDictionary *notificationsForClass, BOOL *stopOuter) {
+                [notificationsForClass enumerateKeysAndObjectsUsingBlock:^(NSString *name, NSSet *objects, BOOL *stopInner) {
                     [NSNotificationCenter.defaultCenter postNotificationName:name object:class userInfo:@{
                         FCModelInstanceSetKey : objects
                     }];


### PR DESCRIPTION
Enabling warnings `-Wshadow` leads to a warning below. 

As the variables are not used, this warning could be safely ignored, but can just as easily be fixed.
