### PR TITLE
Fixed bug that caused NULLable NSNumber properties to be initialized to @(0) instead of nil

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1068,10 +1068,17 @@ static inline void onMainThreadAsync(void (^block)())
                     info.type = FCModelFieldTypeOther;
                     info.defaultValue = nil;
                 }
-                
-                if (isPK) info.defaultValue = nil;
-                else if ([[columnsRS stringForColumnIndex:4] isEqualToString:@"NULL"]) info.defaultValue = nil;
 
+                if(isPK)
+		{
+                    info.defaultValue = nil;
+		}
+                else
+		{
+                    if ([[columnsRS stringForColumnIndex:4] isEqualToString:@"NULL"]) info.defaultValue = nil;
+                    if ([columnsRS columnIndexIsNull:4]) info.defaultValue = nil;
+		}
+                
                 [fields setObject:info forKey:fieldName];
             }
             


### PR DESCRIPTION
Column 4 of pragma table_info() is NULL when a column has no default value, but this isn't detected on INTEGER columns. When the property is a primitive, this isn't an issue as the property gets initialized to zero. But an NSNumber can be nil, and should be when the underlying column is NULL.

Because FCModelFieldInfo.defaultValue gets initialized to @(0) even when the property is nil-able, model properties declared as NSNumber get assigned @(0) instead of nil when the column is nil.

This change tests if column 4 of pragma table_info() is NULL, and clears any values from FCModelFieldInfo.defaultValue if it is.

(Not sure why the existing code tested for the string literal "NULL", so I added my code to it. But perhaps both lines aren't needed?)
