### PR TITLE
Fix reverting unsaved changes for entities with custom (de)serialization

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -716,8 +716,7 @@ static inline void onMainThreadAsync(void (^block)())
 {
     if (! self._rowValuesInDatabase) return;
     [self.unsavedChanges enumerateKeysAndObjectsUsingBlock:^(NSString *fieldName, id obj, BOOL *stop) {
-        id oldValue = self._rowValuesInDatabase[fieldName];
-        if (oldValue) [self setValue:(oldValue == NSNull.null ? nil : oldValue) forKeyPath:fieldName];
+        [self revertUnsavedChangeToFieldName:fieldName];
     }];
 }
 


### PR DESCRIPTION
The issue is (IMHO) that `self._rowValuesInDatabase[fieldName]` yields for `BLOB` columns the unserialized `NSData` object. If however an entity chooses to deserialize this to e.g. `UIImage` the deserialization was not applied when reverting all unsaved changes. The method `revertUnsavedChangeToFieldName:` did so correctly. The following change simply calls `revertUnsavedChangeToFieldName:` for all unsaved columns in `revertUnsavedChanges`.
