### PR TITLE
Added +deleteAll for clearing a table without enumerating through it

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -97,6 +97,7 @@ typedef NS_ENUM(NSInteger, FCModelSaveResult) {
 - (void)revertUnsavedChangeToFieldName:(NSString *)fieldName;
 - (FCModelSaveResult)delete;
 - (FCModelSaveResult)save;
++ (void)deleteAll;
 + (void)saveAll; // Resolved by class: call on FCModel to save all, on a subclass to save just those and their subclasses, etc.
 
 // SELECTs


### PR DESCRIPTION
I'm implementing FCModel in an RSS reader and batch deleting articles when removing an account is very useful.
