### PR TITLE
Refactors cache removal to own method

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -948,6 +948,13 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     [self.class postChangeNotification:FCModelAnyChangeNotification changedFields:[NSSet setWithArray:self.class.databaseFieldNames] instance:self];
 
     // Remove instance from unique map
+    [self removeFromCache];
+    
+    return FCModelSaveSucceeded;
+}
+
+- (void)removeFromCache
+{
     id primaryKeyValue = self.primaryKey;
     if (g_instances && primaryKeyValue && primaryKeyValue != NSNull.null) {
         dispatch_semaphore_wait(g_instancesReadLock, DISPATCH_TIME_FOREVER);
@@ -955,8 +962,6 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
         [classCache removeObjectForKey:primaryKeyValue];
         dispatch_semaphore_signal(g_instancesReadLock);
     }
-    
-    return FCModelSaveSucceeded;
 }
 
 + (void)saveAll


### PR DESCRIPTION
Some of our app logic unit tests, rely on the ability to reset the cache for individual objects in order to properly test serialization/deserialization, deletion rules, etc.. 

We have a +test header file that exposes the `removeFromCache` method. 

This commit changes nothing in the logic of the framework, it does simply move the cache removal to its own method.
