### PR TITLE
Fixed NSDecimalNumber properties deserialization

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -255,6 +255,8 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
         } else if (propertyClass == NSArray.class) {
             NSArray *array = [NSPropertyListSerialization propertyListWithData:databaseValue options:kCFPropertyListImmutable format:NULL error:NULL];
             return array && [array isKindOfClass:NSArray.class] ? array : @[];
+        } else if (propertyClass == NSDecimalNumber.class) {
+            return [NSDecimalNumber decimalNumberWithDecimal:[databaseValue decimalValue]];
         }
     }
 


### PR DESCRIPTION
When I have a NSDecimalNumber property in my model class, FCModel does not touch the value returned from the database and stores a NSNumber in it. (It worked correctly in a previous version of FCModel I used, in the prehistoric-with-autoincrement times).
