### PR TITLE
Creating overridable tableName class method

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -154,6 +154,9 @@ typedef NS_ENUM(NSInteger, FCModelSaveResult) {
 
 // For subclasses to override, all optional:
 
+// For instances where the class's name doesn't linearly line up with the destination table name.
++ (NSString *)tableName;
+
 - (void)didInit;
 - (BOOL)shouldInsert;
 - (BOOL)shouldUpdate;


### PR DESCRIPTION
We are trying to persist a data model that includes the following classes:`Photo`, `Story`, and `Document`.  The vast majority of the properties on these three classes are identical with each class only having a couple of fields specific to that type.  FCModel’s current approach requires us to create three separate SQL tables that duplicate the common data in all of the tables.  This becomes problematic as the model changes and we have to keep all of the tables in sync.

This PR would allow us to create three FCModel subclasses (`Photo`, `Story`, and `Document`) and then map each of those classes to a single database table (an `Artifact` table) that contains columns for all of the common properties and any type specific properties as well.  Mapping the classes to a common table behind the scenes, only requires the subclasses to override the class method `tableName` to return a common name.
