### PR TITLE
postChangeNotification: Send instance, not class

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1282,7 +1282,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     if (! enqueued) {
         onMainThreadAsync(^{
             [NSNotificationCenter.defaultCenter postNotificationName:name object:self.class userInfo:@{
-                FCModelInstanceSetKey : [NSSet setWithObject:self],
+                FCModelInstanceSetKey : [NSSet setWithObject:instance],
                 FCModelChangedFieldsKey : changedFields
             }];
         });


### PR DESCRIPTION
This was sending the class object, rather than the changed instance.
