### PR TITLE
Enforce 'FCModel tables must have a single-column primary key'

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1092,8 +1092,8 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
                 }
                 
                 int isPK = [columnsRS intForColumnIndex:5];
-                if (isPK > primaryKeyColumnCount) {
-                    primaryKeyColumnCount = isPK;
+                if (isPK) {
+                    primaryKeyColumnCount++;
                     primaryKeyName = fieldName;
                 }
 


### PR DESCRIPTION
I tried using `FCModel` with multiple-column tables, and after a while noticed that this isn't supposed to be supported. 

After some digging, I believe I found that `[FCModel openDatabaseAtPath: withDatabaseInitializer: schemaBuilder:]` doesn't throw an exception when it's supposed to. Say I create a 3-column key,

**Before the commit**: `isPK` returns 1 on three passes (the code looks like it's been tested on machines where SQLite returns 1, 2, 3; but I definitely get 1, 1, 1 here), `primaryKeyColumnCount` is set to `1`, contrary to its name. No exception.

**After the commit**: `isPK` returns 1 on three passes, `primaryKeyColumnCount` is incremented 3 times. At the end of the cycle, an exception informs me that multi-column keys are not supported.
