### PR TITLE
Fix for: 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderSet...

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1286,7 +1286,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     if (! enqueued) {
         onMainThreadAsync(^{
             [NSNotificationCenter.defaultCenter postNotificationName:name object:self.class userInfo:@{
-                FCModelInstanceSetKey : [NSSet setWithObject:instance],
+                FCModelInstanceSetKey : instance ? [NSMutableSet setWithObject:instance] : [NSMutableSet set],
                 FCModelChangedFieldsKey : changedFields
             }];
         });


### PR DESCRIPTION
... initWithObjects:count:]: attempt to insert nil object from objects[0]'

The code above this appears to be doing nil checking of instance, whereas this code doesn't, and crashes when instance is nil. I sent it out to our beta testers and already had 22 crashes in an hour so it's definitely a real issue ;)

I'm not familiar enough with FCModel to know if you need to move some of the code above into a common method and use it in both cases or not, but this doesn't appear to be the case?
