### PR TITLE
fix [FCModel databaseIsOpen]

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1205,7 +1205,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     return ! modelsAreStillLoaded;
 }
 
-+ (BOOL)databaseIsOpen { return (BOOL) g_databaseQueue; }
++ (BOOL)databaseIsOpen { return !!g_databaseQueue; }
 
 + (void)inDatabaseSync:(void (^)(FMDatabase *db))block
 {


### PR DESCRIPTION
Hello Marco, 
this was giving me an incorrect answer in some cases, probably because (BOOL) incorrectly truncates the pointer.

I wanted to add some tests, but I noticed that there already exists a test in -testDatabaseCloseFlushesCache for -databaseIsOpen, and I'm not sure having more tests would make sense.

Thanks, Ilya.
