### PR TITLE
Allow PK of different length on +instancesWithPrimaryKeyValues

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -467,6 +467,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     __block NSArray *allFoundInstances = nil;
     NSMutableArray *valuesArray = [NSMutableArray arrayWithCapacity:MIN(primaryKeyValues.count, maxParameterCount)];
     NSMutableString *whereClause = [NSMutableString stringWithFormat:@"%@ IN (", g_primaryKeyFieldName[self]];
+    NSUInteger whereClauseLength = whereClause.length;
     
     void (^fetchChunk)() = ^{
         if (valuesArray.count == 0) return;
@@ -475,7 +476,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
         allFoundInstances = allFoundInstances ? [allFoundInstances arrayByAddingObjectsFromArray:newInstancesThisChunk] : newInstancesThisChunk;
         
         // reset state for next chunk
-        [whereClause deleteCharactersInRange:NSMakeRange(7, whereClause.length - 7)];
+        [whereClause deleteCharactersInRange:NSMakeRange(whereClauseLength, whereClause.length - whereClauseLength)];
         [valuesArray removeAllObjects];
     };
     

--- a/example/FCModelTest Tests/FCModelTest_Tests.m
+++ b/example/FCModelTest Tests/FCModelTest_Tests.m
@@ -188,6 +188,20 @@
     XCTAssertTrue(result && [result isKindOfClass:[NSDictionary class]]);
 }
 
+- (void)testVariableLimit {
+    __block int maxParameterCount = 0;
+    [FCModel inDatabaseSync:^(FMDatabase *db) {
+        maxParameterCount = sqlite3_limit(db.sqliteHandle, SQLITE_LIMIT_VARIABLE_NUMBER, -1);
+    }];
+    
+    NSMutableArray *values = [NSMutableArray arrayWithCapacity:maxParameterCount+1];
+    for (int i = 0; i <= maxParameterCount; i++) {
+        [values addObject:@(i)];
+    }
+    XCTAssertNoThrow([SimpleModel instancesWithPrimaryKeyValues:values]);
+    
+}
+
 - (void)testNotifications
 {
     __block int insertNotificationsClass1 = 0, insertNotificationsClass2 = 0, insertNotificationsNoClass = 0,

--- a/example/FCModelTest.xcodeproj/project.pbxproj
+++ b/example/FCModelTest.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		49B84BD219A5D8850070B159 /* libsqlite3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = A9EEFB1A17E4D2830066C5EA /* libsqlite3.dylib */; };
 		9230D6FB17F32EF1000C9C87 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9230D6FA17F32EF1000C9C87 /* XCTest.framework */; };
 		9230D6FC17F32EF1000C9C87 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9EEFAC217E4C8EE0066C5EA /* Foundation.framework */; };
 		9230D6FD17F32EF1000C9C87 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A9EEFAC617E4C8EE0066C5EA /* UIKit.framework */; };
@@ -109,6 +110,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49B84BD219A5D8850070B159 /* libsqlite3.dylib in Frameworks */,
 				9230D6FB17F32EF1000C9C87 /* XCTest.framework in Frameworks */,
 				9230D6FD17F32EF1000C9C87 /* UIKit.framework in Frameworks */,
 				9230D6FC17F32EF1000C9C87 /* Foundation.framework in Frameworks */,


### PR DESCRIPTION
`instancesWithPrimaryKeyValues:` would construct a bad query if the PK had length != 2 and we were querying for more than SQLITE_LIMIT_VARIABLE_NUMBER primary keys.
The limit is 500000 though, so I suppose it's difficult to hit.
