### PR TITLE
Use OS X 10.6 as deployment target 10.6

### DIFF
--- a/FCModel.podspec
+++ b/FCModel.podspec
@@ -11,5 +11,5 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.dependency 'FMDB', '~> 2.1'
   s.ios.deployment_target = '6.0'
-  s.osx.deployment_target = '10.8'
+  s.osx.deployment_target = '10.6'
 end


### PR DESCRIPTION
NSMapTable is available since 10.5 and the only limitation FCModel has is ARC which has been available since 10.6. I updated the Podspec to use 10.6 as deployment target.
