### PR TITLE
Fix bug if unsavedChangeValue class different with fieldValue class

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -722,6 +722,10 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
                 // Conflict if the value isn't equal to the new DB value.
                 if (unsavedChangeValue == NSNull.null) unsavedChangeValue = nil;
 
+                if (! [unsavedChangeValue isKindOfClass:[fieldValue class]]) {
+                    unsavedChangeValue = [self encodedValueForFieldName:fieldName];
+                }
+
                 if (unsavedChangeValue != fieldValue && ((! unsavedChangeValue || ! fieldValue) || ! [fieldValue isEqual:unsavedChangeValue])) {
                     // Conflict: model was loaded from DB, modified without being saved, and now the reload wants to set a different value
                     fieldValue = [self valueOfFieldName:fieldName byResolvingReloadConflictWithDatabaseValue:fieldValue];


### PR DESCRIPTION
Find a bug when run FCModelTest Demo.

Method `shouldInsert` and `shouldUpdate` will update time in Person Model. Call `executeUpdateQuery`, then unsavedchanges don’t include createTime and modifiedTime changes, when reload, unsavedchangess include createTime and modifiedTime changes but conflict db data, but unsavedChangeValue class is different with fieldValue class, cause an exception.
