### PR TITLE
FCModel openDatabaseAtPath:withSchemaBuilder: blocks on OS X

### DIFF
--- a/FCModel/FCModelDatabaseQueue.m
+++ b/FCModel/FCModelDatabaseQueue.m
@@ -104,9 +104,11 @@
 
         // Read change counter from SQLite file header to detect changes made by other processes during this write
         uint32_t changeCounterBeforeBlock = 0;
-        lseek(changeCounterReadFileDescriptor, kSQLiteFileChangeCounterOffset, SEEK_SET);
-        read(changeCounterReadFileDescriptor, &changeCounterBeforeBlock, sizeof(uint32_t));
-        changeCounterBeforeBlock = CFSwapInt32BigToHost(changeCounterBeforeBlock);
+        if (changeCounterReadFileDescriptor > 0) {
+            lseek(changeCounterReadFileDescriptor, kSQLiteFileChangeCounterOffset, SEEK_SET);
+            read(changeCounterReadFileDescriptor, &changeCounterBeforeBlock, sizeof(uint32_t));
+            changeCounterBeforeBlock = CFSwapInt32BigToHost(changeCounterBeforeBlock);
+        }
         
         block(db);
 
@@ -115,9 +117,11 @@
             
             // if more than 1 change during this expected write, either there's 2 queries in it (unexpected) or another process changed it
             uint32_t changeCounterAfterBlock = 0;
-            lseek(changeCounterReadFileDescriptor, kSQLiteFileChangeCounterOffset, SEEK_SET);
-            read(changeCounterReadFileDescriptor, &changeCounterAfterBlock, sizeof(uint32_t));
-            changeCounterAfterBlock = CFSwapInt32BigToHost(changeCounterAfterBlock);
+            if (changeCounterReadFileDescriptor > 0) {
+                lseek(changeCounterReadFileDescriptor, kSQLiteFileChangeCounterOffset, SEEK_SET);
+                read(changeCounterReadFileDescriptor, &changeCounterAfterBlock, sizeof(uint32_t));
+                changeCounterAfterBlock = CFSwapInt32BigToHost(changeCounterAfterBlock);
+            }
 
             if (changeCounterAfterBlock - changeCounterBeforeBlock > 1) [FCModel dataWasUpdatedExternally];
         });


### PR DESCRIPTION
In a new OS X Cocoa application, I'm unable to call `FCModel openDatabaseAtPath: withSchemaBuilder:` as shown in the example code in the README. The program blocks but doesn't crash. I've traced the problem to this line: https://github.com/marcoarment/FCModel/blob/5932a9c4653e972783ce5eb3589bcf7f85995beb/FCModel/FCModelDatabaseQueue.m#L108

FCModelDatabaseQueue calls `read` on the file descriptor `changeCounterReadFileDescriptor`, but `changeCounterReadFileDescriptor` is not set until `startMonitoringForExternalChanges` has been called which doesn't happen until the end of the `FCModel openDatabaseAtPath: withSchemaBuilder:` method. That means `changeCounterReadFileDescriptor` still has the default value of 0 which points to stdin, which suggests that the problem I'm seeing is the program blocking waiting for input.

Further confusing the issue, after testing in a bare iOS project and a bare OS X project it appears that iOS doesn't block `read()` when called on a file descriptor whose value is `0` while OS X does. 

This is the application code I'm running inside `applicationDidFinishLaunching` /  `didFinishLaunchingWithOptions`:

``` objc
NSString *documentsPath = [NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES) objectAtIndex:0];
NSString *dbPath = [documentsPath stringByAppendingPathComponent:@"testDB.sqlite3"];

NSLog(@"before open");
[FCModel openDatabaseAtPath:dbPath withSchemaBuilder:^(FMDatabase *db, int *schemaVersion) {
    NSLog(@"inside open");
}];
NSLog(@"after open");
```

In the iOS project the console shows:

```
2014-12-10 18:24:42.396 FCModelTest-iOS[29875:1641988] before open
2014-12-10 18:24:42.400 FCModelTest-iOS[29875:1642046] inside open
2014-12-10 18:24:42.402 FCModelTest-iOS[29875:1641988] after open
```

while in OSX I see: 

```
2014-12-10 20:14:17.667 FCModelTest-OSX[31655:303] before open
```

and then nothing.

This commit fixes the problem, but I'm very new to Mac development and I don't know if it's the best/appropriate/idiomatic solution.
