### PR TITLE
Use existsInDatabase property during save to allow overriding

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -480,9 +480,9 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     
         NSDictionary *changes = self.unsavedChanges;
         BOOL dirty = changes.count;
-        if (! dirty && _inDatabaseStatus == FCModelInDatabaseStatusRowExists) { hadChanges = NO; return; }
+        if (! dirty && self.existsInDatabase) { hadChanges = NO; return; }
         
-        BOOL update = (_inDatabaseStatus == FCModelInDatabaseStatusRowExists);
+        BOOL update = self.existsInDatabase;
         NSArray *columnNames;
         NSMutableArray *values;
         


### PR DESCRIPTION
Small change to use the `existsInDatabase` property instead of checking the same thing.

The reason for the change is that I'd like to be able to have models inserted as new instead of updated when they have changes like so:

``` swift
override var existsInDatabase: Bool {
    return super.existsInDatabase & !self.hasUnsavedChanges
}

override func save() -> Bool {
    if self.hasUnsavedChanges {
        self.loadId = Load.primaryKeyValueForNewInstance().longLongValue
    }
    return super.save()
}
```
