### PR TITLE
Exposes the sqliteHandle

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -70,6 +70,7 @@ typedef NS_ENUM(NSInteger, FCModelSaveResult) {
 + (void)openDatabaseAtPath:(NSString *)path withSchemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder;
 + (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder;
 
++ (sqlite3 *) sqliteHandle;
 + (NSArray *)databaseFieldNames;
 + (NSString *)primaryKeyFieldName;
 

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -91,6 +91,8 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 @implementation FCModel
 
++ (sqlite3 *)sqliteHandle { return [[g_databaseQueue database] sqliteHandle]; }
+
 - (NSError *)lastSQLiteError { return self._lastSQLiteError; }
 
 - (BOOL)isDeleted { return deleted; }


### PR DESCRIPTION
I'm using <code>FCModel</code> for a personal project and I would like to add custom C functions to the SQLite underlying database.
I think it could be handy to get the <code>sqlite*</code> handle to be able to achieve this goal.
