### PR TITLE
Fixed linker errors caused by missing files from Xcode project

### DIFF
--- a/example/FCModelTest.xcodeproj/project.pbxproj
+++ b/example/FCModelTest.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		A9EEFB2517E5F5060066C5EA /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = A9EEFB2417E5F5060066C5EA /* Default-568h@2x.png */; };
 		A9EEFB2817E6AF970066C5EA /* Color.m in Sources */ = {isa = PBXBuildFile; fileRef = A9EEFB2717E6AF970066C5EA /* Color.m */; };
 		A9EEFB2C17E6BCF80066C5EA /* FMDatabasePool.m in Sources */ = {isa = PBXBuildFile; fileRef = A9EEFB2B17E6BCF80066C5EA /* FMDatabasePool.m */; };
+		EE9BDA0B1A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9BDA0A1A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.m */; };
+		EE9BDA0E1A9BB7B300EB7E6E /* FCModelNotificationCenter.m in Sources */ = {isa = PBXBuildFile; fileRef = EE9BDA0D1A9BB7B300EB7E6E /* FCModelNotificationCenter.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -106,6 +108,10 @@
 		A9EEFB2717E6AF970066C5EA /* Color.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Color.m; sourceTree = "<group>"; };
 		A9EEFB2A17E6BCF80066C5EA /* FMDatabasePool.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FMDatabasePool.h; sourceTree = "<group>"; };
 		A9EEFB2B17E6BCF80066C5EA /* FMDatabasePool.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FMDatabasePool.m; sourceTree = "<group>"; };
+		EE9BDA091A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FCModelConcurrentMutableDictionary.h; sourceTree = "<group>"; };
+		EE9BDA0A1A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FCModelConcurrentMutableDictionary.m; sourceTree = "<group>"; };
+		EE9BDA0C1A9BB7B300EB7E6E /* FCModelNotificationCenter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FCModelNotificationCenter.h; sourceTree = "<group>"; };
+		EE9BDA0D1A9BB7B300EB7E6E /* FCModelNotificationCenter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FCModelNotificationCenter.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -228,10 +234,14 @@
 			children = (
 				A9EEFAFB17E4CB300066C5EA /* FCModel.h */,
 				A9EEFAFC17E4CB300066C5EA /* FCModel.m */,
+				EE9BDA0C1A9BB7B300EB7E6E /* FCModelNotificationCenter.h */,
+				EE9BDA0D1A9BB7B300EB7E6E /* FCModelNotificationCenter.m */,
 				A9B741F71A36480600CF42CE /* FCModelInstanceCache.h */,
 				A9B741F81A36480600CF42CE /* FCModelInstanceCache.m */,
 				A924EA2D18D0EC94000C28BD /* FCModelCachedObject.h */,
 				A924EA2E18D0EC94000C28BD /* FCModelCachedObject.m */,
+				EE9BDA091A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.h */,
+				EE9BDA0A1A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.m */,
 				A924EA2F18D0EC94000C28BD /* FCModelDatabaseQueue.h */,
 				A924EA3018D0EC94000C28BD /* FCModelDatabaseQueue.m */,
 			);
@@ -375,11 +385,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EE9BDA0B1A9BB7A000EB7E6E /* FCModelConcurrentMutableDictionary.m in Sources */,
 				A9EEFB2817E6AF970066C5EA /* Color.m in Sources */,
 				A9EEFB2C17E6BCF80066C5EA /* FMDatabasePool.m in Sources */,
 				A9EEFB2117E4E39A0066C5EA /* RandomThings.m in Sources */,
 				A924EA3118D0EC94000C28BD /* FCModelCachedObject.m in Sources */,
 				A9B741F91A36480600CF42CE /* FCModelInstanceCache.m in Sources */,
+				EE9BDA0E1A9BB7B300EB7E6E /* FCModelNotificationCenter.m in Sources */,
 				A924EA3218D0EC94000C28BD /* FCModelDatabaseQueue.m in Sources */,
 				A9EEFADC17E4C8EE0066C5EA /* ViewController.m in Sources */,
 				A9EEFAD317E4C8EE0066C5EA /* AppDelegate.m in Sources */,

--- a/example/FCModelTest/AppDelegate.m
+++ b/example/FCModelTest/AppDelegate.m
@@ -116,7 +116,7 @@
     NSMutableSet *colorsUsedAlready = [NSMutableSet set];
     
     // Put some data in the table if there's not enough
-    int numPeople = [Person numberOfInstances];
+    NSUInteger numPeople = [Person numberOfInstances];
     while (numPeople < 26) {
         Person *p = [Person new];
         do {


### PR DESCRIPTION
The following files were added to FCModel during recent commits but
were missing from the Xcode project of the included example app. This
commit adds them back to the project:
- FCModelNotificationCenter.h & .m
- FCModelConcurrentMutableDictionary.h & .m
