### PR TITLE
Support creating duplicate instances in parrallel

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -130,7 +130,8 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
                 id suppliedValue = s.resultDictionary[key];
                 if (suppliedValue) [self setValue:(suppliedValue == NSNull.null ? nil : suppliedValue) forKey:key];
             }];
-
+            
+            _inDatabaseStatus = FCModelInDatabaseStatusRowExists;
             self._rowValuesInDatabase = s.resultDictionary;
         }
         [s close];


### PR DESCRIPTION
I currently get an SQL duplicate primary key exception if I create two objects with the same primary key value and then save them.  The second save fails with a duplicate key exception.  I'm calling reloadAndSave but because both instances are created before either are saved, both objects are marked as needing to be inserted.  This change will update the second object as strictly an update if the reload finds an existing object in the db with the same primary key.