### PR TITLE
Fix issues that prevent FCModel from working with Swift

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -45,6 +45,8 @@ extern NSString * const FCModelChangedFieldsKey;
 @property (readonly) BOOL existsInDatabase; // either deleted or never saved
 @property (readonly) BOOL isDeleted;
 
+// Swift classes have their module name prefixed onto their Objective-C class. To use FCModel with Swift, provide your module name.
+// You can find it in Xcode under Build Settings -> Product Module Name.
 + (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder;
 + (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder moduleName:(NSString *)moduleName;
 

--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -63,6 +63,10 @@ extern NSString * const FCModelChangedFieldsKey;
 // CRUD basics
 + (instancetype)instanceWithPrimaryKey:(id)primaryKeyValue; // will create if nonexistent
 + (instancetype)instanceWithPrimaryKey:(id)primaryKeyValue createIfNonexistent:(BOOL)create; // will return nil if nonexistent
+
+- (instancetype)initWithPrimaryKey:(id)primaryKeyValue;
+- (instancetype)initWithPrimaryKey:(id)primaryKeyValue createIfNonexistent:(BOOL)create;
+
 - (NSArray *)changedFieldNames;
 - (void)revertUnsavedChanges;
 - (void)revertUnsavedChangeToFieldName:(NSString *)fieldName;

--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -46,6 +46,7 @@ extern NSString * const FCModelChangedFieldsKey;
 @property (readonly) BOOL isDeleted;
 
 + (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder;
++ (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder moduleName:(NSString *)moduleName;
 
 + (NSArray *)databaseFieldNames;
 + (NSString *)primaryKeyFieldName;

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -684,7 +684,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 #pragma mark - Utilities
 
-- (id)primaryKey { return [self valueForKey:g_primaryKeyFieldName[self.class]]; }
+- (id)primaryKey { return [self valueForKey:g_primaryKeyFieldName[[self.class tableName]]]; }
 
 + (NSString *)tableName {
     NSString *className = NSStringFromClass(self);

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -684,7 +684,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 #pragma mark - Utilities
 
-- (id)primaryKey { return [self valueForKey:g_primaryKeyFieldName[[self.class tableName]]]; }
+- (id)primaryKey { return [self valueForKey:g_primaryKeyFieldName[self.class]]; }
 
 + (NSString *)tableName {
     NSString *className = NSStringFromClass(self);

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -28,6 +28,7 @@ static FCModelDatabase *g_database = NULL;
 static NSDictionary *g_fieldInfo = NULL;
 static NSDictionary *g_ignoredFieldNames = NULL;
 static NSDictionary *g_primaryKeyFieldName = NULL;
+static NSString *g_modulePrefix = NULL;
 
 typedef NS_ENUM(char, FCModelInDatabaseStatus) {
     FCModelInDatabaseStatusNotYetInserted = 0,
@@ -576,7 +577,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
             NSArray *columnNames;
             NSMutableArray *values;
             
-            NSString *tableName = NSStringFromClass(self.class);
+            NSString *tableName = [self.class tableName];
             NSString *pkName = g_primaryKeyFieldName[self.class];
             id primaryKey = self.primaryKey;
             NSAssert1(primaryKey && (primaryKey != NSNull.null), @"Cannot update %@ without primary key value", NSStringFromClass(self.class));
@@ -685,11 +686,17 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 - (id)primaryKey { return [self valueForKey:g_primaryKeyFieldName[self.class]]; }
 
++ (NSString *)tableName {
+    NSString *className = NSStringFromClass(self);
+    if (g_modulePrefix) className = [className substringFromIndex:g_modulePrefix.length];
+    return className;
+}
+
 + (NSString *)expandQuery:(NSString *)query
 {
     if (self == FCModel.class) return query;
     query = [query stringByReplacingOccurrencesOfString:@"$PK" withString:g_primaryKeyFieldName[self]];
-    return [query stringByReplacingOccurrencesOfString:@"$T" withString:NSStringFromClass(self)];
+    return [query stringByReplacingOccurrencesOfString:@"$T" withString:[self tableName]];
 }
 
 - (NSString *)description
@@ -709,7 +716,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
 - (NSUInteger)hash
 {
-    return NSStringFromClass(self.class).hash ^ ((NSObject *)self.primaryKey).hash;
+    return [self.class tableName].hash ^ ((NSObject *)self.primaryKey).hash;
 }
 
 - (BOOL)isEqual:(id)object
@@ -741,6 +748,11 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 #pragma mark - Database management
 
 + (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder
+{
+    [self openDatabaseAtPath:path withDatabaseInitializer:databaseInitializer schemaBuilder:schemaBuilder moduleName:nil];
+}
+
++ (void)openDatabaseAtPath:(NSString *)path withDatabaseInitializer:(void (^)(FMDatabase *db))databaseInitializer schemaBuilder:(void (^)(FMDatabase *db, int *schemaVersion))schemaBuilder moduleName:(NSString *)moduleName
 {
     NSParameterAssert(NSThread.isMainThread);
     
@@ -774,7 +786,12 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
        ];
         while ([tablesRS next]) {
             NSString *tableName = [tablesRS stringForColumnIndex:0];
-            Class tableModelClass = NSClassFromString(tableName);
+            NSString *tableClass = tableName;
+            if (moduleName) {
+                g_modulePrefix = [moduleName stringByAppendingString:@"."];
+                tableClass = [g_modulePrefix stringByAppendingString:tableClass];
+            }
+            Class tableModelClass = NSClassFromString(tableClass);
             if (! tableModelClass || ! [tableModelClass isSubclassOfClass:self]) continue;
             
             NSString *primaryKeyName = nil;

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -137,6 +137,10 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     return instance;
 }
 
+- (instancetype)initWithPrimaryKey:(id)primaryKeyValue { return [self.class instanceWithPrimaryKey:primaryKeyValue]; }
+- (instancetype)initWithPrimaryKey:(id)primaryKeyValue createIfNonexistent:(BOOL)create { return [self.class instanceWithPrimaryKey:primaryKeyValue createIfNonexistent:create]; }
+- (instancetype)initWithPrimaryKey:(id)primaryKeyValue databaseRowValues:(NSDictionary *)fieldValues createIfNonexistent:(BOOL)create { return [self.class instanceWithPrimaryKey:primaryKeyValue databaseRowValues:fieldValues createIfNonexistent:create]; }
+
 + (instancetype)instanceFromDatabaseWithPrimaryKey:(id)key
 {
     __block FCModel *model = NULL;

--- a/FCModel/FCModelDatabase.m
+++ b/FCModel/FCModelDatabase.m
@@ -7,6 +7,7 @@
 
 #import "FCModelDatabase.h"
 #import "FCModel.h"
+#import <sqlite3.h>
 
 @interface FCModel ()
 + (void)postChangeNotificationWithChangedFields:(NSSet *)changedFields;


### PR DESCRIPTION
* In Objective-C land, Swift classes that subclass an ObjC class get an ObjC counterpart called `Module.Class`. SQLite thinks the module name is a database name, which won’t exist, so we have to take that out.

  I’ve made a change that requires the module name to be passed to `openDatabaseAtPath:…`. I didn’t want to complicate things trying to guess the module name (and it feels hacky searching for and stripping up to a period), so I feel that’s the best way to do it. Everywhere the class name is used in an SQL statement, it’s been replaced with a call to `+tableName`, which returns the name with the module prefix stripped out. Eg: if a model class is `TestApp.People` – `g_modulePrefix` will be `TestApp.`. The table used will be `People`.
* Model objects that provide their own init method can’t call `+instanceWithPrimaryKey:…`; the language seems to not support it. I added `-initWithPrimaryKey:…` methods for this situation.
* There was also an `#import <sqlite3.h>` missing. Not sure if that was a mistake or not, but I added it back in so FCModelDatabase.m compiles.

Issue still unfixed: Swift enums don’t seem to work? Probably because they’re more like Swift objects and not just a primitive type. (Edit: You can just mark the enum as `@objc` to fix that.)

I learned of this project last night, I learned of CompactConstraint a few days ago, and I started using Overcast (again) last week. It’s been a Marco kind of month for me. :+1: for all you do.