### PR TITLE
Improved support for using FMDB as a framework

### DIFF
--- a/FCModel/FCModel.h
+++ b/FCModel/FCModel.h
@@ -8,7 +8,7 @@
 #import <Foundation/Foundation.h>
 #include <AvailabilityMacros.h>
 
-#ifdef COCOAPODS
+#ifdef FMDB_FRAMEWORK
 #import <FMDB/FMDatabase.h>
 #else
 #import "FMDatabase.h"

--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -10,8 +10,15 @@
 #import "FCModel.h"
 #import "FCModelCachedObject.h"
 #import "FCModelDatabaseQueue.h"
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
+
+#ifdef FMDB_FRAMEWORK
+    #import <FMDB/FMDatabase.h>
+    #import <FMDB/FMDatabaseAdditions.h>
+#else
+    #import "FMDatabase.h"
+    #import "FMDatabaseAdditions.h"
+#endif
+
 #import <sqlite3.h>
 #import <Security/Security.h>
 

--- a/FCModel/FCModelDatabaseQueue.h
+++ b/FCModel/FCModelDatabaseQueue.h
@@ -7,7 +7,7 @@
 
 #import <Foundation/Foundation.h>
 
-#ifdef COCOAPODS
+#ifdef FMDB_FRAMEWORK
 #import <FMDB/FMDatabase.h>
 #else
 #import "FMDatabase.h"


### PR DESCRIPTION
I just cleaned it up a bit and made it clear for users of FMDB as a framework (not just CocoaPods, but also Carthage).