### PR TITLE
sqlite unique primary key generation bug

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -635,7 +635,11 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
                         NSAssert1(attempts < 100, @"FCModel subclass %@ is not returning usable, unique values from primaryKeyValueForNewInstance", NSStringFromClass(self.class));
                         
                         id newKeyValue = [self.class primaryKeyValueForNewInstance];
-                        if ([self.class instanceFromDatabaseWithPrimaryKey:newKeyValue]) continue; // already exists in database
+                        if ([self.class instanceFromDatabaseWithPrimaryKey:newKeyValue]) {
+                            conflict = YES;
+                        } else {
+                            conflict = NO;
+                        }
                         [self setValue:newKeyValue forKey:key];
                     } while (conflict);
                     


### PR DESCRIPTION
"continue" statement forces loop condition re-evaluation - while(conflict), this "conflict" value is initialized to false and does not change inside of loop body (loop will repeat itself only if condition is true, but condition is hardcoded false and will exit after first iteration) - loop will execute only once even if non unique primary key was generated, which will result in a sqlite crash (unique pk assertion failure)