### PR TITLE
Fix warning: 'inTransaction' is deprecated, use isInTransaction property instead

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -1113,7 +1113,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 + (BOOL)isInTransaction
 {
     __block BOOL inTransaction = NO;
-    [self inDatabaseSync:^(FMDatabase *db) { inTransaction = db.inTransaction; }];
+    [self inDatabaseSync:^(FMDatabase *db) { inTransaction = db.isInTransaction; }];
     return inTransaction;
 }
 
@@ -1122,7 +1122,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
     __block NSDictionary *changedFieldsToNotify = nil;
 
     [self inDatabaseSync:^(FMDatabase *db) {
-        if (db.inTransaction) [[NSException exceptionWithName:FCModelException reason:@"Cannot nest FCModel transactions" userInfo:nil] raise];
+        if (db.isInTransaction) [[NSException exceptionWithName:FCModelException reason:@"Cannot nest FCModel transactions" userInfo:nil] raise];
         [db beginTransaction];
         g_database.isQueuingNotifications = YES;
         
@@ -1150,7 +1150,7 @@ static inline BOOL checkForOpenDatabaseFatal(BOOL fatal)
 
     __block BOOL success = NO;
     [self inDatabaseSync:^(FMDatabase *db) {
-        if (db.inTransaction) return;
+        if (db.isInTransaction) return;
         queryProfileStart(@"VACUUM");
         [db executeUpdate:@"VACUUM"];
         queryProfileEnd();


### PR DESCRIPTION
Note: This warning comes from `FMDB.framework`, its related commit sha `07e0362` (23 May, 2017).