### PR TITLE
FCModel.m: Rm useless imports

### DIFF
--- a/FCModel/FCModel.m
+++ b/FCModel/FCModel.m
@@ -11,8 +11,6 @@
 #import "FCModelCachedObject.h"
 #import "FCModelDatabase.h"
 #import "FCModelNotificationCenter.h"
-#import "FMDatabase.h"
-#import "FMDatabaseAdditions.h"
 #import <sqlite3.h>
 #import <Security/Security.h>
 


### PR DESCRIPTION
- `FCModel.h` imports "FMDatabase.h" already (maybe we can use `@class FMDatabase;` in `FCModel.h`, and keep it in `FCModel.m`?).

- `FMDatabaseAdditions.h` seems not needed in `FCModel.m`.