### PR TITLE
Add basic SwiftPM support for Objective-C code

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "FMDB",
+        "repositoryURL": "https://github.com/ccgus/fmdb.git",
+        "state": {
+          "branch": null,
+          "revision": "61e51fde7f7aab6554f30ab061cc588b28a97d04",
+          "version": "2.7.7"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.3
+import PackageDescription
+
+let package = Package(
+    name: "FCModel",
+    platforms: [.macOS(.v10_10), .iOS(.v9)],
+    products: [.library(name: "FCModel", targets: ["FCModel"])],
+    dependencies: [
+      .package(name: "FMDB", url: "https://github.com/ccgus/fmdb.git", from: "2.7.7"),
+    ],
+    targets: [
+        .target(
+            name: "FCModel",
+            dependencies: ["FMDB"],
+            path: "FCModel",
+            exclude: ["FCModel+ObservableObject.swift"],
+            publicHeadersPath: "include"
+        )
+    ]
+)


### PR DESCRIPTION
This fixes #158 for the most part. Only the Swift code adding the `ObservableObject` support I couldn't include because SwiftPM didn't want to accept mixed language packages. Maybe that can be fixed by splitting to two targets somehow, but as we don't need it for our project, I didn't invest the time to check. But this should be better than nothing.